### PR TITLE
add seed_testnet.txt and lnd.conf to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ lnd-data/
 thunderhub-data/
 rtl-data/
 seed.txt
+seed_testnet.txt
+lnd.conf


### PR DESCRIPTION
seed_testnet.txt has been added for security reasons
lnd.conf has been added because otherwise it would override the custom modified file from the user